### PR TITLE
Fix not null constraint violation when running the seed

### DIFF
--- a/db/migrate/20190109143111_add_default_author_type.rb
+++ b/db/migrate/20190109143111_add_default_author_type.rb
@@ -1,0 +1,5 @@
+class AddDefaultAuthorType < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :decidim_petitions_petitions, :decidim_author_type, "Decidim::User"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_24_114721) do
+ActiveRecord::Schema.define(version: 2019_01_09_143111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -770,7 +770,7 @@ ActiveRecord::Schema.define(version: 2018_10_24_114721) do
     t.jsonb "json_schema"
     t.integer "votes", default: 0
     t.string "image"
-    t.string "decidim_author_type", null: false
+    t.string "decidim_author_type", default: "Decidim::User", null: false
     t.string "state", default: "closed"
     t.index ["decidim_author_id", "decidim_author_type"], name: "index_decidim_petitions_on_decidim_author"
     t.index ["decidim_component_id"], name: "index_decidim_petitions_petitions_on_decidim_component_id"
@@ -818,7 +818,7 @@ ActiveRecord::Schema.define(version: 2018_10_24_114721) do
     t.bigint "decidim_user_group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "decidim_proposal_id, decidim_author_id, COALESCE(decidim_user_group_id, ('-1'::integer)::bigint)", name: "decidim_proposals_proposal_endorsmt_proposal_auth_ugroup_uniq", unique: true
+    t.index "decidim_proposal_id, decidim_author_id, (COALESCE(decidim_user_group_id, ('-1'::integer)::bigint))", name: "decidim_proposals_proposal_endorsmt_proposal_auth_ugroup_uniq", unique: true
     t.index ["decidim_author_id"], name: "decidim_proposals_proposal_endorsement_author"
     t.index ["decidim_proposal_id"], name: "decidim_proposals_proposal_endorsement_proposal"
     t.index ["decidim_user_group_id"], name: "decidim_proposals_proposal_endorsement_user_group"


### PR DESCRIPTION
@andreslucena Here's the code to reproduce the graphql error
`"Field 'petition' doesn't exist on type ‘Query’”`
which is like master plus a fix for the error pointed in my email (db:seed gives an error because it tries to insert a null decidim_author_type into decidim_petitions table)