### PR TITLE
Adds worker and redis to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ ENV BUNDLE_PATH=/bundle \
     BUNDLE_BIN=/bundle/bin \
     GEM_HOME=/bundle
 ENV PATH="${BUNDLE_BIN}:${PATH}"
-
-ADD . /app
-
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
+ADD decidim-petitions/ /app/decidim-petitions
 RUN bundle install
+
+ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,37 @@ services:
       - DATABASE_HOST=pg
       - DATABASE_USERNAME=postgres
       - RAILS_ENV=development
+      - REDIS_URL=redis://redis:6379
     ports:
       - 3000:3000
     links:
       - pg
+      - redis
     command: bash -c "rm tmp/pids/server.pid ; bundle exec rails server -b 0.0.0.0"
+  worker:
+    build: .
+    volumes:
+      - .:/app
+      - bundle_cache:/bundle
+    environment:
+      - DATABASE_HOST=pg
+      - DATABASE_USERNAME=postgres
+      - RAILS_ENV=development
+      - REDIS_URL=redis://redis:6379
+    links:
+      - pg
+      - redis
+    command: bundle exec sidekiq
   pg:
     image: postgres
     volumes:
       - pg-data:/var/lib/postgresql/data
+  redis:
+    image: redis
+    volumes:
+      - redis-data:/data
 volumes:
   node_modules: {}
   bundle_cache: {}
   pg-data: {}
+  redis-data: {}


### PR DESCRIPTION
Adds the sidekiq worker and redis database to docker-compose.

It also requires to have the decidim-decode-connector on the same directory as DDDC.

`git clone https://github.com/DECODEproject/decidim-decode-connector`

At the moment it doesn't work as it decidim-decode-connector requires to also have docker-compose:

> 
> app_1     |   ↳ decidim-petitions/app/commands/decidim/petitions/admin/activate_petition.rb:21
> app_1     |    (2.9ms)  COMMIT
> app_1     |   ↳ decidim-petitions/app/commands/decidim/petitions/admin/activate_petition.rb:21
> worker_1  | 2019-02-06T15:36:56.763Z 1 TID-gpr045xw9 DecodeConnectorWorker JID-0c6cfa86f333f34b6457743b INFO: start
> worker_1  | make: docker-compose: Command not found
> worker_1  | make: *** [create] Error 127
> worker_1  | Makefile:40: recipe for target 'create' failed
> worker_1  | 2019-02-06T15:36:56.797Z 1 TID-gpr045xw9 DecodeConnectorWorker JID-0c6cfa86f333f34b6457743b INFO: done: 0.034 sec
> app_1     | Redirected to http://localhost:3000/admin/participatory_processes/quibusdam-voluptate/components/20/manage/petitions
> app_1     | Completed 302 Found in 829ms (ActiveRecord: 43.3ms)
> app_1     | 
> 